### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/spiritual-format-validation.yml
+++ b/.github/workflows/spiritual-format-validation.yml
@@ -8,6 +8,9 @@ on:
     types: [opened, edited]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   spiritual-format-validation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/debora-m-lutz/lichtara-os/security/code-scanning/14](https://github.com/debora-m-lutz/lichtara-os/security/code-scanning/14)

To resolve the issue, an explicit `permissions` block should be added to the workflow. Since the workflow primarily reads data (e.g., issue and pull request titles, branch ancestry, and changed files) but does not perform any write operations, it can be configured with minimal permissions such as `contents: read`. This ensures the workflow adheres to the principle of least privilege.

The permissions block can be added at the root level under the workflow name to apply to all jobs, as none of the jobs require distinct permissions. Specifically:
- Add a `permissions` key with `contents: read` to ensure the workflow can read repository contents without write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
